### PR TITLE
Fix [null] array bug in wide format p__* columns

### DIFF
--- a/pqg/sql_converter.py
+++ b/pqg/sql_converter.py
@@ -1696,13 +1696,13 @@ def _build_wide_output_staged(con, output_parquet: str, verbose: bool) -> None:
                 se.p__has_material_category,
                 se.p__has_sample_object_type,
                 se.p__keywords,
-                [se.p__produced_by]::INTEGER[] as p__produced_by,
-                [se.p__registrant]::INTEGER[] as p__registrant,
+                CASE WHEN se.p__produced_by IS NOT NULL THEN [se.p__produced_by] ELSE NULL END::INTEGER[] as p__produced_by,
+                CASE WHEN se.p__registrant IS NOT NULL THEN [se.p__registrant] ELSE NULL END::INTEGER[] as p__registrant,
                 NULL::INTEGER[] as p__responsibility,
                 NULL::INTEGER[] as p__sample_location,
                 NULL::INTEGER[] as p__sampling_site,
                 NULL::INTEGER[] as p__site_location,
-                [se.p__curation]::INTEGER[] as p__curation,
+                CASE WHEN se.p__curation IS NOT NULL THEN [se.p__curation] ELSE NULL END::INTEGER[] as p__curation,
                 se.p__related_resource
             FROM samples samp
             LEFT JOIN sample_edges se ON se.sample_row_id = samp.row_id
@@ -1729,8 +1729,8 @@ def _build_wide_output_staged(con, output_parquet: str, verbose: bool) -> None:
                 NULL::INTEGER[] as p__produced_by,
                 NULL::INTEGER[] as p__registrant,
                 ee.p__responsibility,
-                [ee.p__sample_location]::INTEGER[] as p__sample_location,
-                [ee.p__sampling_site]::INTEGER[] as p__sampling_site,
+                CASE WHEN ee.p__sample_location IS NOT NULL THEN [ee.p__sample_location] ELSE NULL END::INTEGER[] as p__sample_location,
+                CASE WHEN ee.p__sampling_site IS NOT NULL THEN [ee.p__sampling_site] ELSE NULL END::INTEGER[] as p__sampling_site,
                 NULL::INTEGER[] as p__site_location,
                 NULL::INTEGER[] as p__curation,
                 NULL::INTEGER[] as p__related_resource
@@ -1761,7 +1761,7 @@ def _build_wide_output_staged(con, output_parquet: str, verbose: bool) -> None:
                 NULL::INTEGER[] as p__responsibility,
                 NULL::INTEGER[] as p__sample_location,
                 NULL::INTEGER[] as p__sampling_site,
-                [se.p__site_location]::INTEGER[] as p__site_location,
+                CASE WHEN se.p__site_location IS NOT NULL THEN [se.p__site_location] ELSE NULL END::INTEGER[] as p__site_location,
                 NULL::INTEGER[] as p__curation,
                 NULL::INTEGER[] as p__related_resource
             FROM sites site


### PR DESCRIPTION
## Summary
- Fixes issue where wide format p__* columns contained `[null]` arrays instead of proper NULL values
- Closes #8

## Problem
When converting scalar row_ids to arrays for p__* columns in wide format, the pattern `[scalar]::INTEGER[]` creates `[null]` when scalar is NULL, instead of proper NULL.

**Before (buggy):**
| Column | Total NOT NULL | [null] arrays | Real values |
|--------|---------------|---------------|-------------|
| p__curation | 6,680,932 | 5,960,678 | 720,254 |
| p__registrant | 6,680,932 | 1,696,607 | 4,984,325 |
| p__produced_by | 6,680,932 | 326,761 | 6,354,171 |

**After (fixed):**
| Column | Total NOT NULL | [null] arrays | Real values |
|--------|---------------|---------------|-------------|
| p__curation | 720,254 | 0 | 720,254 ✓ |
| p__registrant | 4,984,325 | 0 | 4,984,325 ✓ |
| p__produced_by | 6,354,171 | 0 | 6,354,171 ✓ |

All counts now match narrow format edge counts exactly.

## Fix
Use CASE WHEN to only create array when value is not NULL:
```sql
-- Before
[se.p__curation]::INTEGER[] as p__curation

-- After  
CASE WHEN se.p__curation IS NOT NULL THEN [se.p__curation] ELSE NULL END::INTEGER[] as p__curation
```

Applied to 6 locations in `_build_wide_output_staged()`:
- p__produced_by, p__registrant, p__curation (sample edges)
- p__sample_location, p__sampling_site (event edges)
- p__site_location (site edges)

## Test plan
- [x] Regenerate wide format with fix
- [x] Verify p__curation count matches narrow edge count (720,254)
- [x] Verify p__registrant count matches narrow edge count (4,984,325)
- [x] Verify p__produced_by count matches narrow edge count (6,354,171)
- [x] Verify 0 `[null]` arrays in all affected columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)